### PR TITLE
[19]: mv absolute path from server/constants to index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
 'use strict';
 
 const { ExpressServer } = require(__dirname + '/server/server');
-const { PUBLIC_BUILD_PATH } = require(__dirname + '/server/constants');
+const { DIST_DIRECTORY } = require(__dirname + '/server/constants');
 
 const Server = new ExpressServer();
 
-Server.setStaticDirectory(PUBLIC_BUILD_PATH);
+Server.setStaticDirectory(__dirname + '/' + DIST_DIRECTORY);
 Server.listen(process.env.PORT);

--- a/server/constants.js
+++ b/server/constants.js
@@ -2,11 +2,10 @@
 
 const DEFAULT_PORT = 3000;
 const DIST_DIRECTORY = 'dist';
-const PUBLIC_BUILD_PATH = __dirname + '/' + DIST_DIRECTORY;
 const LISTENING = 'Listening on';
 
 module.exports = {
     DEFAULT_PORT,
-    LISTENING,
-    PUBLIC_BUILD_PATH
+    DIST_DIRECTORY,
+    LISTENING
 };


### PR DESCRIPTION
## Issue
Closes #19 

`__dirname` uses the absolute path coming from the directory it's used in.  In this case, it was looking for `./server/dist` instead of `./dist`.  

<img width="469" alt="screen shot 2018-10-26 at 9 21 06 pm" src="https://user-images.githubusercontent.com/3228720/47599533-1ca06c80-d965-11e8-8a3f-ca9948065a4b.png">

/review @JacobPernell @mskalandunas