### PR TITLE
[80]: add try/catch to createDirectory fn

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,7 +5,15 @@ const { LOGGER_TYPES, MESSAGE_COLORS } = require(__dirname + '/constants');
 
 const checkForDirectory = directoryName => fs.existsSync(directoryName);
 
-const createDirectory = directoryPath => fs.mkdirSync(directoryPath);
+const createDirectory = directoryPath => {
+    try {
+        fs.mkdirSync(directoryPath);
+    }
+
+    catch(err) {
+        logger('Directory already exists.', LOGGER_TYPES.DEFAULT);
+    }
+};
 
 const logger = (message = '', type = LOGGER_TYPES.DEFAULT) =>
     console.log(MESSAGE_COLORS[type], '\n' + message); // eslint-disable-line no-console

--- a/lib/utils.test.js
+++ b/lib/utils.test.js
@@ -28,6 +28,10 @@ describe('createDirectory', () => {
 
         fs.rmdirSync(testDbPath);
     });
+
+    it.skip('should emit a message if the directory already exists', () => {
+
+    });
 });
 
 describe.skip('logger', () => {


### PR DESCRIPTION
## Issue
Closes #80 

No longer errors if a directory already exists, just sends a helpful message instead.  Need to add tests but will do that after I make a general stdout test util.

From the node repl:
<img width="513" alt="screen shot 2018-12-08 at 11 59 25 pm" src="https://user-images.githubusercontent.com/3228720/49694773-57d9b200-fb45-11e8-81cb-713b9af56061.png">

/review @JacobPernell @mskalandunas