### PR TITLE
[47]: add generic validation handler; add username validation

### DIFF
--- a/client/js/service-client/lib/service-client.js
+++ b/client/js/service-client/lib/service-client.js
@@ -31,14 +31,9 @@ const formatUserData = () => {
     const password = 'hunter2';
 
     return {
-        authentication: {
-            basic: {
-                username,
-                password
-            }
-        },
-        username,
-        email
+        email,
+        password,
+        username
     };
 };
 

--- a/service/router/constants.js
+++ b/service/router/constants.js
@@ -1,5 +1,15 @@
 'use strict';
 
+/*
+
+4. What is necessary when creating a password?
+    At least 6 chars, one capital letter, and one number
+
+6. What is the max length of an email field?
+    64 (?)
+
+*/
+
 const RESPONSE_MESSAGES = {
     USER_CREATED: 'User created'
 };

--- a/service/router/utils.js
+++ b/service/router/utils.js
@@ -3,6 +3,18 @@
 const createInstancesWithFixtures = (constructor, fixtures) =>
     fixtures.map(fixture => new constructor({ ...fixture }));
 
+const formatUser = ({ email, password, username }) => ({
+    authentication: {
+        basic: {
+            password,
+            username
+        }
+    },
+    email,
+    username
+});
+
 module.exports = {
-    createInstancesWithFixtures
+    createInstancesWithFixtures,
+    formatUser
 };

--- a/service/router/utils.test.js
+++ b/service/router/utils.test.js
@@ -1,6 +1,9 @@
 'use strict';
 
-const { createInstancesWithFixtures } = require('./utils');
+const {
+    createInstancesWithFixtures,
+    formatUser
+} = require('./utils');
 
 describe('createInstancesWithFixtures', () => {
     it('should return an array of instances when passed an array of props and a class', () => {
@@ -22,6 +25,25 @@ describe('createInstancesWithFixtures', () => {
 
         expected.forEach((instance, i) => {
             expect(instance).toEqual(mockProps[i]);
+        });
+    });
+});
+
+describe('formatUser', () => {
+    it('should format a new user for saving', () => {
+        expect(formatUser({
+            email: 'jim@yahoo.com',
+            password: 'hunter2',
+            username: 'jim'
+        })).toEqual({
+            authentication: {
+                basic: {
+                    password: 'hunter2',
+                    username: 'jim'
+                }
+            },
+            email: 'jim@yahoo.com',
+            username: 'jim'
         });
     });
 });

--- a/service/router/validators/constants.js
+++ b/service/router/validators/constants.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const EMAIL_REQUIREMENTS = {
+    ACCEPTED_CHARACTER_REGEX: /^[a-zA-Z0-9-_]+$/,
+    LENGTH: {
+        MAX: 100,
+        MIN: 4
+    },
+    PRIMITIVE: 'string'
+};
+
+const PASSWORD_REQUIREMENTS = {
+    ACCEPTED_CHARACTER_REGEX: /^[a-zA-Z0-9-_!?;:!@#$%^&*()]+$/,
+    LENGTH: {
+        MAX: 30,
+        MIN: 8
+    },
+    PRIMITIVE: 'string'
+};
+
+const USERNAME_REQUIREMENTS = {
+    ACCEPTED_CHARACTER_REGEX: /^[a-zA-Z0-9-_]+$/,
+    LENGTH: {
+        MAX: 20,
+        MIN: 3
+    },
+    PRIMITIVE: 'string'
+};
+
+module.exports = {
+    EMAIL_REQUIREMENTS,
+    PASSWORD_REQUIREMENTS,
+    USERNAME_REQUIREMENTS
+};

--- a/service/router/validators/utils.js
+++ b/service/router/validators/utils.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const { logger } = require(__dirname + '/../../lib/utils');
+const { LOGGER_TYPES } = require(__dirname + '/../../lib/constants');
+
+const acceptedCharactersValidator = (field, regex) => regex.test(field);
+
+const fieldTypeValidator = (field, type) => typeof field === type;
+
+const gatherValidationErrors = (field, ...validators) => {
+    try {
+        return validators.filter(validator =>
+            !validator.handler(field, validator.source)
+        );
+    }
+
+    catch(error) {
+        logger(error, LOGGER_TYPES.ERROR);
+    }
+};
+
+const lengthValidator = (field, { MIN, MAX }) =>
+    field.length >= MIN && field.length <= MAX;
+
+const validationErrorHandler = (errors = []) =>
+    errors.reduce((errorMessage, { message }) => errorMessage + '\n' + message, '');
+
+module.exports = {
+    acceptedCharactersValidator,
+    gatherValidationErrors,
+    fieldTypeValidator,
+    lengthValidator,
+    validationErrorHandler
+};

--- a/service/router/validators/utils.test.js
+++ b/service/router/validators/utils.test.js
@@ -1,0 +1,74 @@
+'use strict';
+
+const {
+    acceptedCharactersValidator,
+    fieldTypeValidator,
+    gatherValidationErrors,
+    lengthValidator,
+    validationErrorHandler
+} = require(__dirname + '/utils');
+
+describe('acceptedCharactersValidator', () => {
+    it('should return true if the input field matches the input regex', () => {
+        expect(acceptedCharactersValidator('string0_-', /^[a-zA-Z0-9-_]+$/)).toBe(true);
+    });
+
+    it('should return false if the input field does not match the input regex', () => {
+        expect(acceptedCharactersValidator('string0_-!', /^[a-zA-Z0-9-_]+$/)).toBe(false);
+    });
+});
+
+describe('fieldTypeValidator', () => {
+    it('should return true if the input field matches the input type', () => {
+        expect(fieldTypeValidator('string', 'string')).toBe(true);
+    });
+
+    it('should return false if the input field does not match the input type', () => {
+        expect(fieldTypeValidator('string', 'number')).toBe(false);
+    });
+});
+
+describe('lengthValidator', () => {
+    it('should return false if the field is shorter than the input minimum', () => {
+        expect(lengthValidator('test', { MAX: 10, MIN: 5 })).toBe(false);
+    });
+
+    it('should return false if the field is longer than the input maximum', () => {
+        expect(lengthValidator('test is long', { MAX: 10, MIN: 5 })).toBe(false);
+    });
+
+    it('should return true if the input field does not fall short of the minimum ' +
+        'or exceed the maxmimum', () => {
+        expect(lengthValidator('test', { MAX: 5, MIN: 3 })).toBe(true);
+    });
+});
+
+describe('gatherValidationErrors', () => {
+    it('should return a list of fields that have errored', () => {
+        expect(JSON.stringify(gatherValidationErrors(
+            'name',
+            { handler: () => false, validatorName: 'test 1' },
+            { handler: () => true, validatorName: 'test 2' },
+            { handler: () => false, validatorName: 'test 3' }
+        ))).toEqual(JSON.stringify([
+            {
+                handler: () => false,
+                validatorName: 'test 1'
+            },
+            {
+                handler: () => false,
+                validatorName: 'test 3'
+            }
+        ]));
+    });
+});
+
+describe.skip('validationErrorHandler', () => {
+    it('should return a string of all validation error messages that have accumulated', () => {
+        expect(validationErrorHandler([
+            { message: 'error message 1' },
+            { message: 'error message 2' },
+            { message: 'error message 3' }
+        ])).toEqual('error message 1\nerror message 2\nerror message 3');
+    });
+});

--- a/service/router/validators/validators.js
+++ b/service/router/validators/validators.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const {
+    acceptedCharactersValidator,
+    fieldTypeValidator,
+    lengthValidator
+} = require(__dirname + '/utils');
+const { USERNAME_REQUIREMENTS } = require(__dirname + '/constants');
+
+const usernameCharactersValidator = {
+    handler: acceptedCharactersValidator,
+    message: 'username should only be letters, numbers, and "-" + "_"',
+    source: USERNAME_REQUIREMENTS.ACCEPTED_CHARACTER_REGEX
+};
+
+const usernameLengthValidator = {
+    handler: lengthValidator,
+    message: 'username is too long',
+    source: USERNAME_REQUIREMENTS.LENGTH
+};
+
+const usernameTypeValidator = {
+    handler: fieldTypeValidator,
+    message: 'username is not a string',
+    source: USERNAME_REQUIREMENTS.PRIMITIVE
+};
+
+module.exports = {
+    usernameCharactersValidator,
+    usernameLengthValidator,
+    usernameTypeValidator
+};

--- a/service/router/validators/validators.test.js
+++ b/service/router/validators/validators.test.js
@@ -1,0 +1,85 @@
+'use strict';
+
+const {
+    usernameCharactersValidator,
+    usernameLengthValidator,
+    usernameTypeValidator
+} = require(__dirname + '/validators');
+
+describe('usernameCharactersValidator', () => {
+    it('should have a handler property', () => {
+        expect(usernameCharactersValidator.handler).toBeTruthy();
+    });
+
+    it('should have a have a handler property of type "function"', () => {
+        expect(typeof usernameCharactersValidator.handler).toBe('function');
+    });
+
+    it('should have a message property', () => {
+        expect(usernameCharactersValidator.message).toBeTruthy();
+    });
+
+    it('should have a message property of type "string"', () => {
+        expect(typeof usernameCharactersValidator.message).toBe('string');
+    });
+
+    it('should have a source property', () => {
+        expect(usernameCharactersValidator.source).toBeTruthy();
+    });
+
+    it('should have a source property of type "object"', () => {
+        expect(typeof usernameCharactersValidator.source).toBe('object');
+    });
+});
+
+describe.skip('usernameLengthValidator', () => {
+    it('should have a handler property', () => {
+        expect(usernameLengthValidator.handler).toBeTruthy();
+    });
+
+    it('should have a have a handler property of type "function"', () => {
+        expect(typeof usernameLengthValidator.handler).toBe('function');
+    });
+
+    it('should have a message property', () => {
+        expect(usernameLengthValidator.message).toBeTruthy();
+    });
+
+    it('should have a message property of type "string"', () => {
+        expect(typeof usernameLengthValidator.message).toBe('string');
+    });
+
+    it('should have a source property', () => {
+        expect(usernameLengthValidator.source).toBeTruthy();
+    });
+
+    it('should have a source property of type "object"', () => {
+        expect(typeof usernameLengthValidator.source).toBe('object');
+    });
+});
+
+describe.skip('usernameTypeValidator', () => {
+    it('should have a handler property', () => {
+        expect(usernameTypeValidator.handler).toBeTruthy();
+    });
+
+    it('should have a have a handler property of type "function"', () => {
+        expect(typeof usernameTypeValidator.handler).toBe('function');
+    });
+
+    it('should have a message property', () => {
+        expect(usernameTypeValidator.message).toBeTruthy();
+    });
+
+    it('should have a message property of type "string"', () => {
+        expect(typeof usernameTypeValidator.message).toBe('string');
+    });
+
+    it('should have a source property', () => {
+        expect(usernameTypeValidator.source).toBeTruthy();
+    });
+
+    it('should have a source property of type "object"', () => {
+        expect(typeof usernameTypeValidator.source).toBe('object');
+    });
+});


### PR DESCRIPTION
## Issue
Adds a generic validation handler for all of our server side validation needs.  A field value is passed in first, followed by any functions needed to validation that field.  The validation function returns any errors, which are then parsed by an error handler if they exist.

This PR also has all of the username validation handlers.

```
gatherValidationErrors(
    body.username,
    usernameCharactersValidator,
    usernameLengthValidator,
    usernameTypeValidator
);
```

/review @JacobPernell @mskalandunas